### PR TITLE
Update addon requirements

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -8,7 +8,7 @@
     <import addon="script.module.urllib3" version="1.22"/>
     <import addon="script.module.chardet" version="3.0.4"/>
     <import addon="script.module.idna" version="2.6"/>
-    <import addon="script.module.certifi" version="2017.07.27.1"/>
+    <import addon="script.module.certifi" version="2019.9.11"/>
   </requires>
   <extension point="xbmc.python.module"
              library="lib" />


### PR DESCRIPTION
The required version doesn't exist in the repository and this causes the request module to fail to install randomly due to a failed dependency, updating the version should force it to pick the right version 

```
2019-10-02 02:11:38.137 T:140027879225088   ERROR: CCurlFile::Open failed with code 404 for https://mirrors.kodi.tv/addons/leia/script.module.certifi/script.module.certifi-2019.3.9.zip:
2019-10-02 02:11:38.137 T:140027879225088   ERROR: Could not fetch addon location and hash from https://mirrors.kodi.tv/addons/leia/script.module.certifi/script.module.certifi-2019.3.9.zip
2019-10-02 02:11:38.137 T:140027879225088   ERROR: CAddonInstallJob[script.module.certifi]: failed to resolve addon install source path
2019-10-02 02:11:38.138 T:140027879225088   ERROR: CAddonInstallJob[script.module.requests]: failed to install dependency script.module.certifi
```